### PR TITLE
Resolves #49 (Markdown text formatting incorrectly shown as code bloc…

### DIFF
--- a/app/models/outline.rb
+++ b/app/models/outline.rb
@@ -1,10 +1,4 @@
 class Outline < ApplicationRecord
   belongs_to :task
 
-  # Callback method from parent Task to strip out '\' delimeters automatically being
-  # added in the text field in the form.
-  # This is call when the parent Task model (via #edit) is updating.
-  def clean_line_feeds
-    self.contents = self.contents.gsub("\\n", "\n")
-  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,22 +12,4 @@ class Task < ApplicationRecord
   validates :title, presence: true
   validates :synopsis, presence: true
 
-  # Callback to ensure delimiters '\' are automatically deleted from '\\n' in edited & updated outline
-  # :contents field.
-  # Printable linefeeds ("\\n") are removed, as these cause linefeeds to appear as standard text which cannot be
-  # rendered as a new line by view helpers such as simple_format() & markdown()
-  # With the delimiter removed, linefeeds are displayed as line breaks. This avoids the need to use html <br> tags
-  # and keeps the text in :contents "clean" just like it is provided by the AI agent response.
-  
-  # Condietional callback: callback used only if :outline exists; else, a method failure would occur
-  before_update :process_outline, if: :outline 
-
-  private
-
-  # :outline model callback, pre-update
-  def process_outline
-    # call child record custom method
-    outline.clean_line_feeds
-  end
-
 end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -13,11 +13,12 @@
         <p class="mb-3 bg-primary text-light p-3 rounded-3"><%= @task.synopsis %></p>
         <h3>Outline:</h3>
   
-        <div class="mb-3 position-relative" id="div-outline">
+        <div class="mb-3 p-0 position-relative" id="div-outline">
             <!-- A new/empty outline is created by saving an empty string: "" -->
             <% if !@task.outline.contents.empty? %>
                 <% text = @task.outline.contents %>
                 <%= markdown(text) %>
+                
                 <span class="d-flex justify-content-end">
                     <%= link_to raw('<i class="fa-regular fa-trash-can"></i> Delete'), task_outline_path(@task, @task.outline), 
                         data: {turbo_method: :delete, turbo_confirm: "Delete outline?"},

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,6 +1,8 @@
 RubyLLM.configure do |config|
-  config.openai_api_key = ENV["GITHUB_API_TOKEN"] # Current token name (updated for Heroku)
-  config.openai_api_base = "https://models.inference.ai.azure.com"
+  # config.openai_api_key = ENV["GITHUB_API_TOKEN"] # Current token name (updated for Heroku)
+  config.openai_api_key = ENV["OPEN_AI_API_KEY"]
+  # config.openai_api_base = "https://models.inference.ai.azure.com"
+  config.openai_api_base = "https://api.openai.com/v1"
 end
 
 
@@ -13,4 +15,3 @@ end
 #   # config.anthropic_api_key = ENV.fetch('ANTHROPIC_API_KEY', nil)
 #   # ... see Configuration guide for all options ...
 # end
-8


### PR DESCRIPTION
…k). Removed text cleaning callback from Task model, added to Outlines controller to be called by #generate.